### PR TITLE
Fix VirtualQuery implementation

### DIFF
--- a/codegen/lift-hlp/dump_debug.py
+++ b/codegen/lift-hlp/dump_debug.py
@@ -1,0 +1,12 @@
+from watcom_debug_info import try_get_watcom_debug_info
+
+import pefile
+
+import sys
+
+if __name__ == '__main__':
+    fname = sys.argv[1]
+    pe = pefile.PE(fname)
+    debug = try_get_watcom_debug_info(pe, fname)
+    for x in debug:
+        print(f"0x{debug[x]:00000000x} {x}")

--- a/codegen/lift-hlp/watcom_debug_info.py
+++ b/codegen/lift-hlp/watcom_debug_info.py
@@ -35,7 +35,7 @@ def try_get_watcom_debug_info(pe, filename) -> None or list:
 
         f.seek(-info_size, 2)
 
-        # we could have pyelftools, but openwatcom seems to generate somewhat broken DWARF info
+        # we could have used pyelftools, but openwatcom seems to generate somewhat broken DWARF info
         #       and pyelftools doesn't handle it well
         # so, instead we rely on readelf and parse it's output :shrug:
 

--- a/test/unit/PagesRegion.cpp
+++ b/test/unit/PagesRegion.cpp
@@ -6,7 +6,9 @@
 #include "gtest/gtest.h"
 
 #include "mem/mgr/pages_region.h"
+#include "util/visit.h"
 
+using namespace uwin;
 using namespace uwin::mem;
 using namespace uwin::mem::mgr;
 
@@ -21,10 +23,33 @@ TEST(PagesRegion, Basic) {
     ASSERT_TRUE(prg.has_uncommited_pages(trg));
     prg.commit_pages(trg, tprot::rw);
     ASSERT_FALSE(prg.has_uncommited_pages(trg));
+
+    // check a query that does not begin with the region returned, but the returned region is the same as reserved region
+    auto q = prg.query(taddr(0x23000));
+    util::visit(q,
+                [&](query_results::reserved const& r) {
+                    FAIL() << "should have got committed result";
+                }, [&](query_results::committed const& c) {
+                ASSERT_EQ(c.region, trg);
+                ASSERT_EQ(c.base_region, trg);
+                ASSERT_EQ(c.protection, tprot::rw);
+            });
+
     prg.uncommit_pages(tmem_region(0x21000, 0x1000));
     ASSERT_TRUE(prg.has_uncommited_pages(trg));
     ASSERT_FALSE(prg.has_uncommited_pages(tmem_region(0x20000, 0x1000)));
     ASSERT_FALSE(prg.has_uncommited_pages(tmem_region(0x22000, 0xe000)));
+
+    // check a query that does not begin with the region returned, returned region != reserved region
+    q = prg.query(taddr(0x23000));
+    util::visit(q,
+                [&](query_results::reserved const& r) {
+        FAIL() << "should have got committed result";
+    }, [&](query_results::committed const& c) {
+        ASSERT_EQ(c.region, tmem_region(0x22000, 0xe000));
+        ASSERT_EQ(c.base_region, trg);
+        ASSERT_EQ(c.protection, tprot::rw);
+    });
 
     prg.reprotect_pages(tmem_region(0x22000, 0xe000), tprot::r);
     prg.uncommit_pages(trg);

--- a/uwin/main.cpp
+++ b/uwin/main.cpp
@@ -220,12 +220,16 @@ int main(int argc, char** argv) {
             state.process_ctx = &process_ctx;
             state.thread_ctx = &thread_ctx;
 
-            auto stack_region = mgr.reserve_dynamic(0x10000);
+            auto stack_region = mgr.reserve_dynamic(0x400000 /* 4 MiB */);
 
             mgr.commit(stack_region, mem::mgr::tprot::rw);
 
+            log::debug("Allocated stack region: {}", stack_region);
+
             auto teb_region = mgr.reserve_dynamic(0x1000);
             mgr.commit(teb_region, mem::mgr::tprot::rw);
+
+            log::debug("Allocated teb region: {}", teb_region);
 
 
             state.addr.fs_base.dword = teb_region.begin().value();

--- a/uwin/mem/mgr/target_mem_mgr.cpp
+++ b/uwin/mem/mgr/target_mem_mgr.cpp
@@ -183,4 +183,8 @@ namespace uwin::mem::mgr {
             map.erase(map.size() - 1);
         return map;
     }
+
+    void *target_mem_mgr::ptr_raw(taddr::tvalue addr) const {
+        return ptr(taddr(addr));
+    }
 }

--- a/uwin/mem/mgr/target_mem_mgr.h
+++ b/uwin/mem/mgr/target_mem_mgr.h
@@ -94,11 +94,13 @@ namespace uwin::mem::mgr {
         }
 
         template<typename T>
-        inline auto ptr(tcptr<T> addr) const {
+        [[nodiscard]] inline auto ptr(tcptr<T> addr) const {
             auto res = _host_region.begin() + addr.value();
             assert(res < _host_region.end());
             return reinterpret_cast<T const *>(res);
         }
+
+        [[nodiscard]] [[maybe_unused]] void* ptr_raw(taddr::tvalue addr) const;
 
         [[nodiscard]] inline hmem_region ptr(tmem_region const &region) const {
             return {ptr<std::uint8_t>(region.begin()), region.size()};


### PR DESCRIPTION
When the query is done into the middle of the region, the beginning should be returned
Also increase default stack size (caused OpenWatcom executables to fail) and add a quick'n'dirty dump_debug.py to dump symbols from OpenWatcom executable